### PR TITLE
feat: Add results file input for Scorecard data

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,33 @@ jobs:
           discovery-orgs: 'UlisesGascon,nodejs'
 ```
 
+### With a results file
+
+If you have a Scorecard results file (e.g., from `scorecard --org --format=json2` or from [Allstar](https://github.com/ossf/allstar)'s `-results-file` flag), you can feed it directly into scorecard-monitor without querying the public API:
+
+```yml
+name: "OpenSSF Scoring"
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  security-scoring:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: OpenSSF Scorecard Monitor
+        uses: ossf/scorecard-monitor@v2.0.0-beta8
+        with:
+          results-path: reporting/results.json
+          database: reporting/database.json
+          report: reporting/openssf-scorecard-report.md
+          auto-commit: true
+          auto-push: true
+```
+
 ### Options
 
 - `scope`: Defines the path to the file where the scope is defined
@@ -132,6 +159,7 @@ jobs:
 - `report-end-tag`: Defines the closing tag, default `<!-- OPENSSF-SCORECARD-MONITOR:END -->`
 - `render-badge`: Defines if the OpenSSF Scorecard badge must be rendered in the reporter to only show the score
 - `report-tool`: Defines the reporting review tool in place: `scorecard-visualizer` [Example](https://ossf.github.io/scorecard-visualizer/#/projects/github.com/nodejs/node) or `deps.dev` [Example](https://deps.dev/project/github/nodejs%2Fnode), by default `scorecard-visualizer`
+- `results-path`: Path to a Scorecard results JSON file. When provided, scores are read from this file instead of the public Scorecard API. The file should contain an array of Scorecard JSON v2 result objects (e.g., from `scorecard --format=json2`, `scorecard --org`, or [Allstar](https://github.com/ossf/allstar)). When set, the `scope` input is not required.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,8 @@ author: 'OpenSSF Scorecard Authors'
 
 inputs:
   scope:
-    description: 'File that includes the list of repositories to monitor'
-    required: true
+    description: 'File that includes the list of repositories to monitor. Required when not using local-results-path.'
+    required: false
   database:
     description: 'File that stores the state of the scorecard'
     required: true
@@ -63,7 +63,15 @@ inputs:
     description: 'Tool to be included as link in the report'
     required: false
     default: "scorecard-visualizer"
-  
+  local-results-path:
+    description: >-
+      Path to a local Scorecard results JSON file. When provided, scores
+      are read from this file instead of the public Scorecard API. The file
+      should contain an array of Scorecard JSON v2 result objects (the
+      output of scorecard --format=json2). When set, the scope input is
+      not required.
+    required: false
+
 outputs:
   scores:
     description: 'Score data in JSON format'

--- a/action.yml
+++ b/action.yml
@@ -63,13 +63,13 @@ inputs:
     description: 'Tool to be included as link in the report'
     required: false
     default: "scorecard-visualizer"
-  local-results-path:
+  results-path:
     description: >-
-      Path to a local Scorecard results JSON file. When provided, scores
-      are read from this file instead of the public Scorecard API. The file
-      should contain an array of Scorecard JSON v2 result objects (the
-      output of scorecard --format=json2). When set, the scope input is
-      not required.
+      Path to a Scorecard results JSON file. When provided, scores are
+      read from this file instead of the public Scorecard API. The file
+      should contain an array of Scorecard JSON v2 result objects (e.g.,
+      from scorecard --format=json2, scorecard --org, or Allstar).
+      When set, the scope input is not required.
     required: false
 
 outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -47266,63 +47266,98 @@ const generateScope = async ({ octokit, orgs, scope, maxRequestInParallel }) => 
   return newScope
 }
 
-const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool }) => {
+/**
+ * Parse local Scorecard results (Scorecard JSON v2 format) into the
+ * internal score format used by scorecard-monitor.
+ * @param {Array} results - Array of Scorecard JSON v2 result objects
+ * @returns {Array} - Array of {score, date, commit, platform, org, repo}
+ */
+const parseLocalResults = (results) => {
+  return results.map((x) => {
+    const parts = x.repo.name.split('/')
+    return {
+      score: x.score,
+      date: x.date,
+      commit: x.repo.commit,
+      platform: parts[0],
+      org: parts[1],
+      repo: parts[2]
+    }
+  })
+}
+
+const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath }) => {
   // @TODO: Improve deep clone logic
   const database = JSON.parse(JSON.stringify(currentDatabase))
-  const platform = 'github.com'
 
-  // @TODO: End the action if there are no projects in scope?
+  let rawScores = []
 
-  const orgs = Object.keys(scope[platform])
-  core.debug(`Total Orgs/Users in scope: ${orgs.length}`)
+  if (localResultsPath) {
+    // Local results mode: read scores from a Scorecard JSON v2 file
+    const { readFile } = (__nccwpck_require__(7147).promises)
+    const content = await readFile(localResultsPath, 'utf8')
+    const results = JSON.parse(content)
+    rawScores = parseLocalResults(Array.isArray(results) ? results : [results])
+    core.debug(`Loaded ${rawScores.length} scores from local results file: ${localResultsPath}`)
+  } else {
+    // API mode: fetch scores from the public Scorecard API
+    const platform = 'github.com'
 
-  // Structure Projects
-  const projects = []
+    // @TODO: End the action if there are no projects in scope?
 
-  orgs.forEach((org) => {
-    const repos = scope[platform][org].included
-    repos.forEach((repo) => projects.push({ org, repo }))
-  })
+    const orgs = Object.keys(scope[platform])
+    core.debug(`Total Orgs/Users in scope: ${orgs.length}`)
 
-  core.debug(`Total Projects in scope: ${projects.length}`)
+    // Structure Projects
+    const projects = []
 
-  const chunks = chunkArray(projects, maxRequestInParallel)
-  core.debug(`Total chunks: ${chunks.length}`)
+    orgs.forEach((org) => {
+      const repos = scope[platform][org].included
+      repos.forEach((repo) => projects.push({ org, repo }))
+    })
 
-  const scores = []
+    core.debug(`Total Projects in scope: ${projects.length}`)
 
-  for (let index = 0; index < chunks.length; index++) {
-    const chunk = chunks[index]
-    core.debug(`Processing chunk ${index + 1}/${chunks.length}`)
+    const chunks = chunkArray(projects, maxRequestInParallel)
+    core.debug(`Total chunks: ${chunks.length}`)
 
-    const chunkScores = await Promise.all(chunk.map(async ({ org, repo }) => {
-      const { score, date, commit } = await getProjectScore({ platform, org, repo })
-      core.debug(`Got project score for ${platform}/${org}/${repo}: ${score} (${date})`)
+    for (let index = 0; index < chunks.length; index++) {
+      const chunk = chunks[index]
+      core.debug(`Processing chunk ${index + 1}/${chunks.length}`)
 
-      const storedScore = getScore({ database, platform, org, repo })
+      const chunkScores = await Promise.all(chunk.map(async ({ org, repo }) => {
+        const { score, date, commit } = await getProjectScore({ platform, org, repo })
+        core.debug(`Got project score for ${platform}/${org}/${repo}: ${score} (${date})`)
+        return { score, date, commit, platform, org, repo }
+      }))
 
-      const scoreData = { platform, org, repo, score, date, commit }
-      // If no stored score then record if score is different then:
-      if (!storedScore || storedScore.score !== score) {
-        saveScore({ database, platform, org, repo, score, date, commit })
-      }
-
-      // Add previous score and date if available to the report
-      if (storedScore) {
-        scoreData.prevScore = storedScore.score
-        scoreData.prevDate = storedScore.date
-        scoreData.prevCommit = storedScore.commit
-
-        if (storedScore.score !== score) {
-          scoreData.currentDiff = parseFloat((score - storedScore.score).toFixed(1))
-        }
-      }
-
-      return scoreData
-    }))
-
-    scores.push(...chunkScores)
+      rawScores.push(...chunkScores)
+    }
   }
+
+  // Common path: enrich scores with database history
+  const scores = rawScores.map(({ score, date, commit, platform, org, repo }) => {
+    const storedScore = getScore({ database, platform, org, repo })
+    const scoreData = { platform, org, repo, score, date, commit }
+
+    // If no stored score then record if score is different then:
+    if (!storedScore || storedScore.score !== score) {
+      saveScore({ database, platform, org, repo, score, date, commit })
+    }
+
+    // Add previous score and date if available to the report
+    if (storedScore) {
+      scoreData.prevScore = storedScore.score
+      scoreData.prevDate = storedScore.date
+      scoreData.prevCommit = storedScore.commit
+
+      if (storedScore.score !== score) {
+        scoreData.currentDiff = parseFloat((score - storedScore.score).toFixed(1))
+      }
+    }
+
+    return scoreData
+  })
 
   core.debug('All the scores are already collected')
 
@@ -49452,9 +49487,10 @@ async function run () {
   // Context
   const context = github.context
   // Inputs
-  const scopePath = core.getInput('scope', { required: true })
+  const scopePath = core.getInput('scope')
   const databasePath = core.getInput('database', { required: true })
   const reportPath = core.getInput('report', { required: true })
+  const localResultsPath = core.getInput('local-results-path')
   // Options
   const maxRequestInParallel = parseInt(core.getInput('max-request-in-parallel') || 10)
   const generateIssue = normalizeBoolean(core.getInput('generate-issue'))
@@ -49494,23 +49530,28 @@ async function run () {
   let scope = { 'github.com': {} }
   let originalReportContent = ''
 
-  // check if scope exists
-  core.info('Checking if scope file exists...')
-  const existScopeFile = existsSync(scopePath)
-  if (!existScopeFile && !discoveryEnabled) {
-    throw new Error('Scope file does not exist and discovery is not enabled')
-  }
+  // In local results mode, scope is discovered from the results file
+  if (!localResultsPath) {
+    // check if scope exists
+    core.info('Checking if scope file exists...')
+    const existScopeFile = existsSync(scopePath)
+    if (!existScopeFile && !discoveryEnabled) {
+      throw new Error('Scope file does not exist and discovery is not enabled')
+    }
 
-  // Use scope file if it exists
-  if (existScopeFile) {
-    core.debug('Scope file exists, using it...')
-    scope = await readFile(scopePath, 'utf8').then(content => JSON.parse(content))
-    validateScopeIntegrity(scope)
-  }
+    // Use scope file if it exists
+    if (existScopeFile) {
+      core.debug('Scope file exists, using it...')
+      scope = await readFile(scopePath, 'utf8').then(content => JSON.parse(content))
+      validateScopeIntegrity(scope)
+    }
 
-  if (discoveryEnabled) {
-    core.info(`Starting discovery for the organizations ${discoveryOrgs}...`)
-    scope = await generateScope({ octokit, orgs: discoveryOrgs, scope, maxRequestInParallel })
+    if (discoveryEnabled) {
+      core.info(`Starting discovery for the organizations ${discoveryOrgs}...`)
+      scope = await generateScope({ octokit, orgs: discoveryOrgs, scope, maxRequestInParallel })
+    }
+  } else {
+    core.info(`Using local results from: ${localResultsPath}`)
   }
 
   // Check if database exists and load it
@@ -49529,7 +49570,7 @@ async function run () {
 
   // PROCESS
   core.info('Generating scores...')
-  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool })
+  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath })
 
   core.info('Checking database changes...')
   const hasChanges = isDifferent(database, newDatabaseState)

--- a/dist/index.js
+++ b/dist/index.js
@@ -47267,12 +47267,12 @@ const generateScope = async ({ octokit, orgs, scope, maxRequestInParallel }) => 
 }
 
 /**
- * Parse local Scorecard results (Scorecard JSON v2 format) into the
+ * Parse Scorecard results (Scorecard JSON v2 format) into the
  * internal score format used by scorecard-monitor.
  * @param {Array} results - Array of Scorecard JSON v2 result objects
  * @returns {Array} - Array of {score, date, commit, platform, org, repo}
  */
-const parseLocalResults = (results) => {
+const parseResults = (results) => {
   return results.map((x) => {
     const parts = x.repo.name.split('/')
     return {
@@ -47286,19 +47286,19 @@ const parseLocalResults = (results) => {
   })
 }
 
-const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath }) => {
+const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, resultsPath }) => {
   // @TODO: Improve deep clone logic
   const database = JSON.parse(JSON.stringify(currentDatabase))
 
   let rawScores = []
 
-  if (localResultsPath) {
-    // Local results mode: read scores from a Scorecard JSON v2 file
+  if (resultsPath) {
+    // Results file mode: read scores from a Scorecard JSON v2 file
     const { readFile } = (__nccwpck_require__(7147).promises)
-    const content = await readFile(localResultsPath, 'utf8')
+    const content = await readFile(resultsPath, 'utf8')
     const results = JSON.parse(content)
-    rawScores = parseLocalResults(Array.isArray(results) ? results : [results])
-    core.debug(`Loaded ${rawScores.length} scores from local results file: ${localResultsPath}`)
+    rawScores = parseResults(Array.isArray(results) ? results : [results])
+    core.debug(`Loaded ${rawScores.length} scores from results file: ${resultsPath}`)
   } else {
     // API mode: fetch scores from the public Scorecard API
     const platform = 'github.com'
@@ -49490,7 +49490,7 @@ async function run () {
   const scopePath = core.getInput('scope')
   const databasePath = core.getInput('database', { required: true })
   const reportPath = core.getInput('report', { required: true })
-  const localResultsPath = core.getInput('local-results-path')
+  const resultsPath = core.getInput('results-path')
   // Options
   const maxRequestInParallel = parseInt(core.getInput('max-request-in-parallel') || 10)
   const generateIssue = normalizeBoolean(core.getInput('generate-issue'))
@@ -49531,7 +49531,7 @@ async function run () {
   let originalReportContent = ''
 
   // In local results mode, scope is discovered from the results file
-  if (!localResultsPath) {
+  if (!resultsPath) {
     // check if scope exists
     core.info('Checking if scope file exists...')
     const existScopeFile = existsSync(scopePath)
@@ -49551,7 +49551,7 @@ async function run () {
       scope = await generateScope({ octokit, orgs: discoveryOrgs, scope, maxRequestInParallel })
     }
   } else {
-    core.info(`Using local results from: ${localResultsPath}`)
+    core.info(`Using results from file: ${resultsPath}`)
   }
 
   // Check if database exists and load it
@@ -49570,7 +49570,7 @@ async function run () {
 
   // PROCESS
   core.info('Generating scores...')
-  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath })
+  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, resultsPath })
 
   core.info('Checking database changes...')
   const hasChanges = isDifferent(database, newDatabaseState)

--- a/src/action.js
+++ b/src/action.js
@@ -71,12 +71,10 @@ async function run () {
   // Context
   const context = github.context
   // Inputs
-  const scopePath = 'scope.json'
-  const databasePath = 'databasefile.json'
-  const reportPath = 'reportfile.md'
-  // const scopePath = core.getInput('scope', { required: true })
-  // const databasePath = core.getInput('database', { required: true })
-  // const reportPath = core.getInput('report', { required: true })
+  const scopePath = core.getInput('scope')
+  const databasePath = core.getInput('database', { required: true })
+  const reportPath = core.getInput('report', { required: true })
+  const localResultsPath = core.getInput('local-results-path')
   // Options
   const maxRequestInParallel = parseInt(core.getInput('max-request-in-parallel') || 10)
   const generateIssue = normalizeBoolean(core.getInput('generate-issue'))
@@ -116,23 +114,28 @@ async function run () {
   let scope = { 'github.com': {} }
   let originalReportContent = ''
 
-  // check if scope exists
-  core.info('Checking if scope file exists...')
-  const existScopeFile = existsSync(scopePath)
-  if (!existScopeFile && !discoveryEnabled) {
-    throw new Error('Scope file does not exist and discovery is not enabled')
-  }
+  // In local results mode, scope is discovered from the results file
+  if (!localResultsPath) {
+    // check if scope exists
+    core.info('Checking if scope file exists...')
+    const existScopeFile = existsSync(scopePath)
+    if (!existScopeFile && !discoveryEnabled) {
+      throw new Error('Scope file does not exist and discovery is not enabled')
+    }
 
-  // Use scope file if it exists
-  if (existScopeFile) {
-    core.debug('Scope file exists, using it...')
-    scope = await readFile(scopePath, 'utf8').then(content => JSON.parse(content))
-    validateScopeIntegrity(scope)
-  }
+    // Use scope file if it exists
+    if (existScopeFile) {
+      core.debug('Scope file exists, using it...')
+      scope = await readFile(scopePath, 'utf8').then(content => JSON.parse(content))
+      validateScopeIntegrity(scope)
+    }
 
-  if (discoveryEnabled) {
-    core.info(`Starting discovery for the organizations ${discoveryOrgs}...`)
-    scope = await generateScope({ octokit, orgs: discoveryOrgs, scope, maxRequestInParallel })
+    if (discoveryEnabled) {
+      core.info(`Starting discovery for the organizations ${discoveryOrgs}...`)
+      scope = await generateScope({ octokit, orgs: discoveryOrgs, scope, maxRequestInParallel })
+    }
+  } else {
+    core.info(`Using local results from: ${localResultsPath}`)
   }
 
   // Check if database exists and load it
@@ -151,7 +154,7 @@ async function run () {
 
   // PROCESS
   core.info('Generating scores...')
-  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool })
+  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath })
 
   core.info('Checking database changes...')
   const hasChanges = isDifferent(database, newDatabaseState)

--- a/src/action.js
+++ b/src/action.js
@@ -74,7 +74,7 @@ async function run () {
   const scopePath = core.getInput('scope')
   const databasePath = core.getInput('database', { required: true })
   const reportPath = core.getInput('report', { required: true })
-  const localResultsPath = core.getInput('local-results-path')
+  const resultsPath = core.getInput('results-path')
   // Options
   const maxRequestInParallel = parseInt(core.getInput('max-request-in-parallel') || 10)
   const generateIssue = normalizeBoolean(core.getInput('generate-issue'))
@@ -115,7 +115,7 @@ async function run () {
   let originalReportContent = ''
 
   // In local results mode, scope is discovered from the results file
-  if (!localResultsPath) {
+  if (!resultsPath) {
     // check if scope exists
     core.info('Checking if scope file exists...')
     const existScopeFile = existsSync(scopePath)
@@ -135,7 +135,7 @@ async function run () {
       scope = await generateScope({ octokit, orgs: discoveryOrgs, scope, maxRequestInParallel })
     }
   } else {
-    core.info(`Using local results from: ${localResultsPath}`)
+    core.info(`Using results from file: ${resultsPath}`)
   }
 
   // Check if database exists and load it
@@ -154,7 +154,7 @@ async function run () {
 
   // PROCESS
   core.info('Generating scores...')
-  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath })
+  const { reportContent, issueContent, database: newDatabaseState } = await generateScores({ scope, database, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, resultsPath })
 
   core.info('Checking database changes...')
   const hasChanges = isDifferent(database, newDatabaseState)

--- a/src/action.js
+++ b/src/action.js
@@ -71,9 +71,12 @@ async function run () {
   // Context
   const context = github.context
   // Inputs
-  const scopePath = core.getInput('scope', { required: true })
-  const databasePath = core.getInput('database', { required: true })
-  const reportPath = core.getInput('report', { required: true })
+  const scopePath = 'scope.json'
+  const databasePath = 'databasefile.json'
+  const reportPath = 'reportfile.md'
+  // const scopePath = core.getInput('scope', { required: true })
+  // const databasePath = core.getInput('database', { required: true })
+  // const reportPath = core.getInput('report', { required: true })
   // Options
   const maxRequestInParallel = parseInt(core.getInput('max-request-in-parallel') || 10)
   const generateIssue = normalizeBoolean(core.getInput('generate-issue'))

--- a/src/index.js
+++ b/src/index.js
@@ -98,87 +98,98 @@ const generateScope = async ({ octokit, orgs, scope, maxRequestInParallel }) => 
   return newScope
 }
 
-const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool }) => {
+/**
+ * Parse local Scorecard results (Scorecard JSON v2 format) into the
+ * internal score format used by scorecard-monitor.
+ * @param {Array} results - Array of Scorecard JSON v2 result objects
+ * @returns {Array} - Array of {score, date, commit, platform, org, repo}
+ */
+const parseLocalResults = (results) => {
+  return results.map((x) => {
+    const parts = x.repo.name.split('/')
+    return {
+      score: x.score,
+      date: x.date,
+      commit: x.repo.commit,
+      platform: parts[0],
+      org: parts[1],
+      repo: parts[2]
+    }
+  })
+}
+
+const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath }) => {
   // @TODO: Improve deep clone logic
   const database = JSON.parse(JSON.stringify(currentDatabase))
-  // const platform = 'github.com'
 
-  // // @TODO: End the action if there are no projects in scope?
+  let rawScores = []
 
-  // const orgs = Object.keys(scope[platform])
-  // core.debug(`Total Orgs/Users in scope: ${orgs.length}`)
+  if (localResultsPath) {
+    // Local results mode: read scores from a Scorecard JSON v2 file
+    const { readFile } = require('fs').promises
+    const content = await readFile(localResultsPath, 'utf8')
+    const results = JSON.parse(content)
+    rawScores = parseLocalResults(Array.isArray(results) ? results : [results])
+    core.debug(`Loaded ${rawScores.length} scores from local results file: ${localResultsPath}`)
+  } else {
+    // API mode: fetch scores from the public Scorecard API
+    const platform = 'github.com'
 
-  // // Structure Projects
-  // const projects = []
+    // @TODO: End the action if there are no projects in scope?
 
-  // orgs.forEach((org) => {
-  //   const repos = scope[platform][org].included
-  //   repos.forEach((repo) => projects.push({ org, repo }))
-  // })
+    const orgs = Object.keys(scope[platform])
+    core.debug(`Total Orgs/Users in scope: ${orgs.length}`)
 
-  // core.debug(`Total Projects in scope: ${projects.length}`)
+    // Structure Projects
+    const projects = []
 
-  // const chunks = chunkArray(projects, maxRequestInParallel)
-  // core.debug(`Total chunks: ${chunks.length}`)
-
-  // const scores = []
-
-  // for (let index = 0; index < chunks.length; index++) {
-  //   const chunk = chunks[index]
-  //   core.debug(`Processing chunk ${index + 1}/${chunks.length}`)
-
-  //   const chunkScores = await Promise.all(chunk.map(async ({ org, repo }) => {
-  //     const { score, date, commit } = await getProjectScore({ platform, org, repo })
-  //     core.debug(`Got project score for ${platform}/${org}/${repo}: ${score} (${date})`)
-
-  //     const storedScore = getScore({ database, platform, org, repo })
-
-  //     const scoreData = { platform, org, repo, score, date, commit }
-  //     // If no stored score then record if score is different then:
-  //     if (!storedScore || storedScore.score !== score) {
-  //       saveScore({ database, platform, org, repo, score, date, commit })
-  //     }
-
-  //     // Add previous score and date if available to the report
-  //     if (storedScore) {
-  //       scoreData.prevScore = storedScore.score
-  //       scoreData.prevDate = storedScore.date
-  //       scoreData.prevCommit = storedScore.commit
-
-  //       if (storedScore.score !== score) {
-  //         scoreData.currentDiff = parseFloat((score - storedScore.score).toFixed(1))
-  //       }
-  //     }
-
-  //     return scoreData
-  //   }))
-
-  //   scores.push(...chunkScores)
-  // }
-
-    let localScores = await getLocalScores(scoredata)
-
-    const scores = localScores.map(({ score, date, commit, platform, org, repo }) => {
-        const storedScore = getScore({ database, platform, org, repo })
-        const scoreData = { platform, org, repo, score, date, commit }
-
-        if (!storedScore || storedScore.score !== score) {
-            saveScore({ database, platform, org, repo, score, date, commit })
-        }
-
-        // Add previous score and date if available to the report
-        if (storedScore) {
-            scoreData.prevScore = storedScore.score
-            scoreData.prevDate = storedScore.date
-            scoreData.prevCommit = storedScore.commit
-
-            if (storedScore.score !== score) {
-                scoreData.currentDiff = parseFloat((score - storedScore.score).toFixed(1))
-            }
-        }
-
-        return scoreData
+    orgs.forEach((org) => {
+      const repos = scope[platform][org].included
+      repos.forEach((repo) => projects.push({ org, repo }))
     })
+
+    core.debug(`Total Projects in scope: ${projects.length}`)
+
+    const chunks = chunkArray(projects, maxRequestInParallel)
+    core.debug(`Total chunks: ${chunks.length}`)
+
+    for (let index = 0; index < chunks.length; index++) {
+      const chunk = chunks[index]
+      core.debug(`Processing chunk ${index + 1}/${chunks.length}`)
+
+      const chunkScores = await Promise.all(chunk.map(async ({ org, repo }) => {
+        const { score, date, commit } = await getProjectScore({ platform, org, repo })
+        core.debug(`Got project score for ${platform}/${org}/${repo}: ${score} (${date})`)
+        return { score, date, commit, platform, org, repo }
+      }))
+
+      rawScores.push(...chunkScores)
+    }
+  }
+
+  // Common path: enrich scores with database history
+  const scores = rawScores.map(({ score, date, commit, platform, org, repo }) => {
+    const storedScore = getScore({ database, platform, org, repo })
+    const scoreData = { platform, org, repo, score, date, commit }
+
+    // If no stored score then record if score is different then:
+    if (!storedScore || storedScore.score !== score) {
+      saveScore({ database, platform, org, repo, score, date, commit })
+    }
+
+    // Add previous score and date if available to the report
+    if (storedScore) {
+      scoreData.prevScore = storedScore.score
+      scoreData.prevDate = storedScore.date
+      scoreData.prevCommit = storedScore.commit
+
+      if (storedScore.score !== score) {
+        scoreData.currentDiff = parseFloat((score - storedScore.score).toFixed(1))
+      }
+    }
+
+    return scoreData
+  })
 
   core.debug('All the scores are already collected')
 
@@ -194,19 +205,4 @@ const generateScores = async ({ scope, database: currentDatabase, maxRequestInPa
 module.exports = {
   generateScope,
   generateScores
-}
-
-let scoredata = require('../results.json')
-
-const getLocalScores = async ( scores ) => {
-    return scores.map((x) => {
-        const parts = x.repo.name.split('/');
-        score = x.score
-        date = x.date
-        commit = x.repo.commit
-        platform = parts[0]
-        org = parts[1]
-        repo = parts[2]
-        return { score, date, commit, platform, org, repo }
-    })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -99,12 +99,12 @@ const generateScope = async ({ octokit, orgs, scope, maxRequestInParallel }) => 
 }
 
 /**
- * Parse local Scorecard results (Scorecard JSON v2 format) into the
+ * Parse Scorecard results (Scorecard JSON v2 format) into the
  * internal score format used by scorecard-monitor.
  * @param {Array} results - Array of Scorecard JSON v2 result objects
  * @returns {Array} - Array of {score, date, commit, platform, org, repo}
  */
-const parseLocalResults = (results) => {
+const parseResults = (results) => {
   return results.map((x) => {
     const parts = x.repo.name.split('/')
     return {
@@ -118,19 +118,19 @@ const parseLocalResults = (results) => {
   })
 }
 
-const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, localResultsPath }) => {
+const generateScores = async ({ scope, database: currentDatabase, maxRequestInParallel, reportTagsEnabled, renderBadge, reportTool, resultsPath }) => {
   // @TODO: Improve deep clone logic
   const database = JSON.parse(JSON.stringify(currentDatabase))
 
   let rawScores = []
 
-  if (localResultsPath) {
-    // Local results mode: read scores from a Scorecard JSON v2 file
+  if (resultsPath) {
+    // Results file mode: read scores from a Scorecard JSON v2 file
     const { readFile } = require('fs').promises
-    const content = await readFile(localResultsPath, 'utf8')
+    const content = await readFile(resultsPath, 'utf8')
     const results = JSON.parse(content)
-    rawScores = parseLocalResults(Array.isArray(results) ? results : [results])
-    core.debug(`Loaded ${rawScores.length} scores from local results file: ${localResultsPath}`)
+    rawScores = parseResults(Array.isArray(results) ? results : [results])
+    core.debug(`Loaded ${rawScores.length} scores from results file: ${resultsPath}`)
   } else {
     // API mode: fetch scores from the public Scorecard API
     const platform = 'github.com'


### PR DESCRIPTION
## Summary

Add a `results-path` Action input that enables reading Scorecard results from a JSON file instead of the public Scorecard API. This enables integration with tools that produce Scorecard results directly, such as [Allstar](https://github.com/ossf/allstar) and Scorecard's own `--org` multi-repo scanning ([ossf/scorecard#4793](https://github.com/ossf/scorecard/pull/4793)).

Supersedes the experimental hack from commit 51b8e77 with a proper, configurable implementation that supports both API and file-based results modes.

## Changes

- **action.yml**: Add `results-path` input; make `scope` not required (repos discovered from results)
- **src/index.js**: Refactor `generateScores()` to support both API and file-based results via conditional logic. Both paths converge to the same database enrichment (history, deltas, report generation). Remove hardcoded `require('../results.json')`.
- **src/action.js**: Restore input reading (was hardcoded by the hack); pass `resultsPath` to `generateScores()`; skip scope validation when results file is provided.
- **dist/index.js**: Rebuilt via `ncc`
- **README.md**: Document `results-path` input and add usage example

## Results file format

The input file should contain an array of [Scorecard JSON v2](https://github.com/ossf/scorecard) results:

```json
[
  {
    "date": "2026-03-28T15:30:00Z",
    "repo": {
      "name": "github.com/org/repo",
      "commit": "abc123..."
    },
    "score": 6.6,
    "checks": [...]
  }
]
```

## Usage

```yaml
- uses: ossf/scorecard-monitor@local-results
  with:
    database: database.json
    report: report.md
    results-path: results.json
    auto-commit: true
    auto-push: true
```

## Related PRs

- [ossf/allstar#800](https://github.com/ossf/allstar/pull/800) — adds `-results-file` flag to Allstar (producing end)
- [ossf/scorecard#4793](https://github.com/ossf/scorecard/pull/4793) — Scorecard `--org` multi-repo scanning

## Test plan

- [x] All 26 existing tests pass
- [x] Manual test: results file parsed correctly (2 repos)
- [x] End-to-end: Allstar produces Scorecard JSON v2 (11 repos) -> scorecard-monitor consumes it -> valid Markdown report with all repos
- [x] API mode: backward compatible (default behavior unchanged when `results-path` not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)